### PR TITLE
downgrade get port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -589,13 +589,6 @@
       "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "requires": {
         "mime-db": ">= 1.40.0 < 2"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.42.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-          "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
-        }
       }
     },
     "compression": {
@@ -1251,12 +1244,9 @@
       "dev": true
     },
     "get-port": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
-      "integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
-      "requires": {
-        "type-fest": "^0.3.0"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+      "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -2240,11 +2230,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2594,7 +2579,7 @@
       }
     },
     "screener-runner": {
-      "version": "github:xwa130saucer/screener-runner#cee5480f050f9d5734534e1a97ae568fa7f08230",
+      "version": "github:xwa130saucer/screener-runner#616ad03888c895a0c199ac5a987349172d52cccc",
       "from": "github:xwa130saucer/screener-runner#vslt/vslt-74-integrate-sc",
       "requires": {
         "bluebird": "~3.4.6",
@@ -3034,11 +3019,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
-    },
-    "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bluebird": "~3.4.6",
     "colors": "~1.1.2",
     "commander": "~2.9.0",
-    "get-port": "~5.0.0",
+    "get-port": "~4.2.0",
     "joi": "~14.3.1",
     "js-yaml": "^3.13.1",
     "lodash": "~4.17.13",


### PR DESCRIPTION
We downgrade the `get-port` module from version `5.0.0` to version `4.2.0` in this PR.
The main reason for doing this is because in node version 6.17.0(latest LTS), when run a test suit, it throws the error: `unexpected token` because of this line: 
https://github.com/sindresorhus/get-port/blob/master/index.js#L24

After we downgrade the version, it could successfully run a test in saucelabs:
https://app.saucelabs.com/builds/fdeb21058d154f329860e236659d94bc